### PR TITLE
Correção de email link

### DIFF
--- a/themes/womoz-brasil/footer.php
+++ b/themes/womoz-brasil/footer.php
@@ -65,7 +65,7 @@ $zerif_socials_email = get_theme_mod('zerif_socials_email','#');
 					endif;
 					// email
 					if( !empty($zerif_socials_email) ):
-						echo '<li><a target="_blank" href="'.esc_url($zerif_socials_email).'"><i class="fa fa-envelope-o"></i></a></li>';
+						echo '<li><a target="_self" href="'.$zerif_socials_email.'"><i class="fa fa-envelope-o"></i></a></li>';
 					endif;
 					?>
 				</ul>


### PR DESCRIPTION
De: 
`<a target="_blank" href="http://womoz@mozillabrasil.org.br">`

Para:
`<a target="_self" href="mailto:womoz@mozillabrasil.org.br">`
